### PR TITLE
Fix yaml loading issues with later rubies.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.6.3', '2.7.6', '3.0.5', '3.1.4', '3.2.2', '3.3.7', '3.4.1']
+        ruby_version: ['2.7.6', '3.0.5', '3.1.4', '3.2.2', '3.3.7', '3.4.1']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Cache Gems
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{matrix.ruby_version}}-resource_registry-gems-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Gemfile' ) }}

--- a/lib/resource_registry/serializers/yaml/deserialize.rb
+++ b/lib/resource_registry/serializers/yaml/deserialize.rb
@@ -19,13 +19,24 @@ module ResourceRegistry
         private
 
         def transform(params)
-          # result = JSON.parse(ERB.new(JSON::dump(YAML.load(params))).result)
-
-          result = YAML.load(ERB.new(params).result)
+          result = call_deserialize(params)
           Success(result || {})
         rescue Psych::SyntaxError => e
           raise "YAML syntax error occurred while parsing #{params}. " \
                 "Error: #{e.message}"
+        end
+
+        def call_deserialize(params)
+          if ResourceRegistry.stdgem_ruby_version?
+            YAML.load(
+              ERB.new(params).result,
+              permitted_classes: [Date, Time, Symbol]
+            )
+          else
+            YAML.load(
+              ERB.new(params).result
+            )
+          end
         end
       end
     end

--- a/spec/resource_registry/complex_data_types_compatibility_spec.rb
+++ b/spec/resource_registry/complex_data_types_compatibility_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ResourceRegistry, "loading configurations with complex data types" do
+  ComplexDataTypeRegistry = ResourceRegistry::Registry.new
+
+  before :all do
+    ComplexDataTypeRegistry.configure do |config|
+      config.name       = :enroll
+      config.created_at = DateTime.now
+      config.load_path  = File.join(
+        File.dirname(__FILE__),
+        "../system/test_registries"
+      )
+    end
+  end
+
+  it "loads the date type feature item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_date_type_items].item).to be_kind_of(Date)
+  end
+
+  it "loads the date range type feature item as a string" do
+    expect(ComplexDataTypeRegistry[:rr_loads_date_range_type_items].item).to be_kind_of(String)
+  end
+
+  it "loads the time type feature item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_time_type_items].item).to be_kind_of(Time)
+  end
+
+  it "loads the symbol type feature item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_symbol_type_items].item).to be_kind_of(Symbol)
+  end
+
+  it "loads the date type setting item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_date_type_items].setting(:rr_loads_date_type_settings).item).to be_kind_of(Date)
+  end
+
+  it "loads the date range type setting item as a string" do
+    expect(ComplexDataTypeRegistry[:rr_loads_date_range_type_items].setting(:rr_loads_date_range_type_settings).item).to be_kind_of(Range)
+  end
+
+  it "loads the time type setting item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_time_type_items].setting(:rr_loads_time_type_settings).item).to be_kind_of(Time)
+  end
+
+  it "loads the symbol type setting item" do
+    expect(ComplexDataTypeRegistry[:rr_loads_symbol_type_items].setting(:rr_loads_symbol_type_settings).item).to be_kind_of(Symbol)
+  end
+end

--- a/spec/system/test_registries/data_type_loading_registry.yml
+++ b/spec/system/test_registries/data_type_loading_registry.yml
@@ -1,0 +1,33 @@
+# This set of keys exists to test YAML of specialized types.
+# There is significant differences in what is considered 'safe' to load from
+#   YAML from Ruby version to ruby version - this makes sure we can load
+#   settings which cover all the bases.
+---
+registry:
+  - namespace:
+    - :resource_registry
+    features:
+      - key: rr_loads_date_type_items
+        item: <%= Date.new(2020,11,1) %>
+        is_enabled: true
+        settings:
+          - key: :rr_loads_date_type_settings
+            item: <%= Date.new(2020,11,1) %>
+      - key: rr_loads_date_range_type_items
+        item: <%= Date.new(2020,11,1)..Date.new(2021,10,31) %>
+        is_enabled: true
+        settings:
+          - key: :rr_loads_date_range_type_settings
+            item: <%= Date.new(2020,11,1)..Date.new(2021,10,31) %>
+      - key: rr_loads_time_type_items
+        item: <%= Time.now %>
+        is_enabled: true
+        settings:
+          - key: :rr_loads_time_type_settings
+            item: <%= Time.now %>
+      - key: rr_loads_symbol_type_items
+        item: :the_item
+        is_enabled: true
+        settings:
+          - key: :rr_loads_symbol_type_settings
+            item: :the_setting


### PR DESCRIPTION
In Ruby versions >= 3.1, it is required to explicitly list which 'special' classes (such as Date, Time, and Symbol) you wish to load when parsing a specific YAML file.  If these are not specified the value will be rejected.

This adds the specified, known, values as well as specs for them to resource registry.