### PR TITLE
Update RR settings to support string-based date ranges

### DIFF
--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -27,34 +27,50 @@ module ResourceRegistry
     attribute :meta,    ResourceRegistry::Meta.optional.meta(omittable: true)
 
     # Override accessor to normalize date range strings
-    def item
-      @normalized_item ||= convert_range_strings(self[:item])
-    end
-
-    private
-
-    def convert_range_strings(value)
-      return value if value.is_a?(Range)
-
-      if value.is_a?(String) && value.include?("..")
-        begin_str, end_str = value.split("..").map(&:strip)
-        if looks_like_date?(begin_str) && looks_like_date?(end_str)
-          begin_date = parse_date(begin_str)
-          end_date = parse_date(end_str)
-          return (begin_date..end_date) if begin_date && end_date
-          return nil
-        end
+      def item
+        @normalized_item ||= convert_range_strings(self[:item])
       end
 
-      value
-    end
+      private
 
-    def looks_like_date?(str)
-      [
-        /^\d{4}-\d{1,2}-\d{1,2}$/, # 2025-01-01
-        /^\d{4}\/\d{1,2}\/\d{1,2}$/, # 2025/01/01
-        /^\d{1,2}\/\d{1,2}\/\d{4}$/ # 01/01/2025
-      ].any? { |re| str.match?(re) }
+      def convert_range_strings(value)
+        return value if value.is_a?(Range)
+
+        if value.is_a?(String) && value.include?("..")
+          begin_str, end_str = value.split("..").map(&:strip)
+
+          # Only try to parse if both ends look like dates
+          if looks_like_date?(begin_str) && looks_like_date?(end_str)
+            begin_date = parse_date(begin_str)
+            end_date = parse_date(end_str)
+            return (begin_date..end_date) if begin_date && end_date
+            return nil
+          end
+          return value
+        end
+        value
+      end
+
+      def looks_like_date?(str)
+        [
+          /^\d{4}-\d{1,2}-\d{1,2}$/,
+          /^\d{4}\/\d{1,2}\/\d{1,2}$/,
+          /^\d{1,2}\/\d{1,2}\/\d{4}$/
+        ].any? { |re| str.match?(re) }
+      end
+
+      def parse_date(str)
+        case str
+        when /^\d{4}-\d{1,2}-\d{1,2}$/
+          Date.strptime(str, "%Y-%m-%d")
+        when /^\d{4}\/\d{1,2}\/\d{1,2}$/
+          Date.strptime(str, "%Y/%m/%d")
+        when /^\d{1,2}\/\d{1,2}\/\d{4}$/
+          Date.strptime(str, "%m/%d/%Y")
+        else
+          nil
+        end
+      end
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -76,6 +76,8 @@ module ResourceRegistry
       else
         nil
       end
+    rescue Date::Error, ArgumentError
+      nil
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -26,6 +26,29 @@ module ResourceRegistry
     # @return [ResourceRegistry::Meta]
     attribute :meta,    ResourceRegistry::Meta.optional.meta(omittable: true)
 
+    # Override accessor to normalize date range strings
+    def item
+      @normalized_item ||= convert_range_strings(super)
+    end
 
+    private
+
+    def convert_range_strings(value)
+      return value if value.is_a?(Range)
+
+      if value.is_a?(String) && value.include?("..")
+        begin_str, end_str = value.split("..")
+        begin_date = parse_date(begin_str.strip)
+        end_date = parse_date(end_str.strip)
+
+        return Range.new(begin_date, end_date) if begin_date && end_date
+      end
+
+      value
+    end
+
+    def parse_date(str)
+      Date.strptime(str, "%m/%d/%Y") rescue Date.parse(str) rescue nil
+    end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -48,20 +48,16 @@ module ResourceRegistry
     end
 
     def parse_date(str)
-      # Accepts: YYYY-MM-DD, YYYY/MM/DD, MM/DD/YYYY
-      date_formats = [
-        "%Y-%m-%d",
-        "%Y/%m/%d",
-        "%m/%d/%Y"
-      ]
-      date_formats.each do |fmt|
-        begin
-          return Date.strptime(str, fmt)
-        rescue ArgumentError
-          next
-        end
+      case str
+      when /^\d{4}-\d{1,2}-\d{1,2}$/ # 2025-01-01
+        Date.strptime(str, "%Y-%m-%d")
+      when /^\d{4}\/\d{1,2}\/\d{1,2}$/ # 2025/01/01
+        Date.strptime(str, "%Y/%m/%d")
+      when /^\d{1,2}\/\d{1,2}\/\d{4}$/ # 01/01/2025
+        Date.strptime(str, "%m/%d/%Y")
+      else
+        nil
       end
-      nil
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -27,49 +27,48 @@ module ResourceRegistry
     attribute :meta,    ResourceRegistry::Meta.optional.meta(omittable: true)
 
     # Override accessor to normalize date range strings
-      def item
-        @normalized_item ||= convert_range_strings(self[:item])
-      end
+    def item
+      @normalized_item ||= convert_range_strings(self[:item])
+    end
 
-      private
+    private
 
-      def convert_range_strings(value)
-        return value if value.is_a?(Range)
+    def convert_range_strings(value)
+      return value if value.is_a?(Range)
 
-        if value.is_a?(String) && value.include?("..")
-          begin_str, end_str = value.split("..").map(&:strip)
+      if value.is_a?(String) && value.include?("..")
+        begin_str, end_str = value.split("..").map(&:strip)
 
-          # Only try to parse if both ends look like dates
-          if looks_like_date?(begin_str) && looks_like_date?(end_str)
-            begin_date = parse_date(begin_str)
-            end_date = parse_date(end_str)
-            return (begin_date..end_date) if begin_date && end_date
-            return nil
-          end
-          return value
+        # Only try to parse if both ends look like dates
+        if looks_like_date?(begin_str) && looks_like_date?(end_str)
+          begin_date = parse_date(begin_str)
+          end_date = parse_date(end_str)
+          return (begin_date..end_date) if begin_date && end_date
+          return nil
         end
-        value
+        return value
       end
+      value
+    end
 
-      def looks_like_date?(str)
-        [
-          /^\d{4}-\d{1,2}-\d{1,2}$/,
-          /^\d{4}\/\d{1,2}\/\d{1,2}$/,
-          /^\d{1,2}\/\d{1,2}\/\d{4}$/
-        ].any? { |re| str.match?(re) }
-      end
+    def looks_like_date?(str)
+      [
+        /^\d{4}-\d{1,2}-\d{1,2}$/,
+        /^\d{4}\/\d{1,2}\/\d{1,2}$/,
+        /^\d{1,2}\/\d{1,2}\/\d{4}$/
+      ].any? { |re| str.match?(re) }
+    end
 
-      def parse_date(str)
-        case str
-        when /^\d{4}-\d{1,2}-\d{1,2}$/
-          Date.strptime(str, "%Y-%m-%d")
-        when /^\d{4}\/\d{1,2}\/\d{1,2}$/
-          Date.strptime(str, "%Y/%m/%d")
-        when /^\d{1,2}\/\d{1,2}\/\d{4}$/
-          Date.strptime(str, "%m/%d/%Y")
-        else
-          nil
-        end
+    def parse_date(str)
+      case str
+      when /^\d{4}-\d{1,2}-\d{1,2}$/
+        Date.strptime(str, "%Y-%m-%d")
+      when /^\d{4}\/\d{1,2}\/\d{1,2}$/
+        Date.strptime(str, "%Y/%m/%d")
+      when /^\d{1,2}\/\d{1,2}\/\d{4}$/
+        Date.strptime(str, "%m/%d/%Y")
+      else
+        nil
       end
     end
   end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -37,18 +37,31 @@ module ResourceRegistry
       return value if value.is_a?(Range)
 
       if value.is_a?(String) && value.include?("..")
-        begin_str, end_str = value.split("..")
-        begin_date = parse_date(begin_str.strip)
-        end_date = parse_date(end_str.strip)
-
-        return Range.new(begin_date, end_date) if begin_date && end_date
+        begin_str, end_str = value.split("..").map(&:strip)
+        begin_date = parse_date(begin_str)
+        end_date = parse_date(end_str)
+        return (begin_date..end_date) if begin_date && end_date
+        return nil
       end
 
       value
     end
 
     def parse_date(str)
-      Date.strptime(str, "%m/%d/%Y") rescue Date.parse(str) rescue nil
+      # Accepts: YYYY-MM-DD, YYYY/MM/DD, MM/DD/YYYY
+      date_formats = [
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%m/%d/%Y"
+      ]
+      date_formats.each do |fmt|
+        begin
+          return Date.strptime(str, fmt)
+        rescue ArgumentError
+          next
+        end
+      end
+      nil
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -28,7 +28,7 @@ module ResourceRegistry
 
     # Override accessor to normalize date range strings
     def item
-      @normalized_item ||= convert_range_strings(super)
+      @normalized_item ||= convert_range_strings(self[:item])
     end
 
     private

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -76,8 +76,6 @@ module ResourceRegistry
       else
         nil
       end
-    rescue Date::Error, ArgumentError
-      nil
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -38,26 +38,23 @@ module ResourceRegistry
 
       if value.is_a?(String) && value.include?("..")
         begin_str, end_str = value.split("..").map(&:strip)
-        begin_date = parse_date(begin_str)
-        end_date = parse_date(end_str)
-        return (begin_date..end_date) if begin_date && end_date
-        return nil
+        if looks_like_date?(begin_str) && looks_like_date?(end_str)
+          begin_date = parse_date(begin_str)
+          end_date = parse_date(end_str)
+          return (begin_date..end_date) if begin_date && end_date
+          return nil
+        end
       end
 
       value
     end
 
-    def parse_date(str)
-      case str
-      when /^\d{4}-\d{1,2}-\d{1,2}$/ # 2025-01-01
-        Date.strptime(str, "%Y-%m-%d")
-      when /^\d{4}\/\d{1,2}\/\d{1,2}$/ # 2025/01/01
-        Date.strptime(str, "%Y/%m/%d")
-      when /^\d{1,2}\/\d{1,2}\/\d{4}$/ # 01/01/2025
-        Date.strptime(str, "%m/%d/%Y")
-      else
-        nil
-      end
+    def looks_like_date?(str)
+      [
+        /^\d{4}-\d{1,2}-\d{1,2}$/, # 2025-01-01
+        /^\d{4}\/\d{1,2}\/\d{1,2}$/, # 2025/01/01
+        /^\d{1,2}\/\d{1,2}\/\d{4}$/ # 01/01/2025
+      ].any? { |re| str.match?(re) }
     end
   end
 end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -28,7 +28,7 @@ module ResourceRegistry
 
     # Override accessor to normalize date range strings
     def item
-      @normalized_item ||= convert_range_strings(self[:item])
+      convert_range_strings(self[:item])
     end
 
     private
@@ -37,12 +37,12 @@ module ResourceRegistry
       return value if value.is_a?(Range)
 
       if value.is_a?(String) && value.include?("..")
-        begin_str, end_str = value.split("..").map(&:strip)
+        begin_str, end_str = value.split("..", 2).map(&:strip)
 
         # Only try to parse if both ends look like dates
         if looks_like_date?(begin_str) && looks_like_date?(end_str)
           begin_date = parse_date(begin_str)
-          end_date = parse_date(end_str)
+          end_date   = parse_date(end_str)
           return (begin_date..end_date) if begin_date && end_date
           return nil
         end

--- a/lib/resource_registry/setting.rb
+++ b/lib/resource_registry/setting.rb
@@ -34,29 +34,35 @@ module ResourceRegistry
     private
 
     def convert_range_strings(value)
-      return value if value.is_a?(Range)
+      return value unless value.is_a?(String)
+      return value unless value.include?('..')
 
-      if value.is_a?(String) && value.include?("..")
-        begin_str, end_str = value.split("..", 2).map(&:strip)
-
-        # Only try to parse if both ends look like dates
-        if looks_like_date?(begin_str) && looks_like_date?(end_str)
-          begin_date = parse_date(begin_str)
-          end_date   = parse_date(end_str)
-          return (begin_date..end_date) if begin_date && end_date
-          return nil
-        end
-        return value
-      end
-      value
+      range, success = attempt_to_convert_to_date_range(value)
+      success ? range : value
     end
 
+    def attempt_to_convert_to_date_range(value)
+      split_result = value.split('..', 2).map(&:strip)
+      return [value, false] if split_result.size != 2
+
+      begin_str, end_str = split_result
+      return [value, false] unless looks_like_date?(begin_str) && looks_like_date?(end_str)
+
+      begin_date = parse_date(begin_str)
+      end_date   = parse_date(end_str)
+      return [value, false] unless begin_date && end_date
+
+      [(begin_date..end_date), true]
+    end
+
+    DATE_PATTERNS = [
+      /^\d{4}-\d{1,2}-\d{1,2}$/,
+      /^\d{4}\/\d{1,2}\/\d{1,2}$/,
+      /^\d{1,2}\/\d{1,2}\/\d{4}$/
+    ].freeze
+
     def looks_like_date?(str)
-      [
-        /^\d{4}-\d{1,2}-\d{1,2}$/,
-        /^\d{4}\/\d{1,2}\/\d{1,2}$/,
-        /^\d{1,2}\/\d{1,2}\/\d{4}$/
-      ].any? { |re| str.match?(re) }
+      DATE_PATTERNS.any? { |re| str.match?(re) }
     end
 
     def parse_date(str)

--- a/spec/resource_registry/setting_spec.rb
+++ b/spec/resource_registry/setting_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ResourceRegistry::Setting do
 
     it "returns nil for non-date ranges" do
       setting = described_class.new(key: :period, item: "1..10")
-      expect(setting.item).to be_nil
+      expect(setting.item).to eq("1..10")
     end
 
     it "returns a Range<Date> as-is" do

--- a/spec/resource_registry/setting_spec.rb
+++ b/spec/resource_registry/setting_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ResourceRegistry::Setting do
   let(:optional_params) { { meta: meta, options: options } }
   let(:all_params)      { required_params.merge(optional_params) }
 
-
   context "Validation with invalid input" do
     context "Given hash params are nissing required attributes" do
       let(:error_hash)  { {} }
@@ -66,6 +65,39 @@ RSpec.describe ResourceRegistry::Setting do
     it "should invoke the class with the passed options parameters" do
       setting = described_class.new(all_params)
       expect(setting[:item].call(setting[:options])).to eq greet_message
+    end
+  end
+
+  context "#item date range normalization" do
+    it "parses YYYY-MM-DD..YYYY-MM-DD as a date range" do
+      setting = described_class.new(key: :period, item: "2025-1-1..2025-12-1")
+      expect(setting.item).to eq(Date.new(2025, 1, 1)..Date.new(2025, 12, 1))
+    end
+
+    it "parses YYYY/MM/DD..YYYY/MM/DD as a date range" do
+      setting = described_class.new(key: :period, item: "2025/01/01..2025/12/1")
+      expect(setting.item).to eq(Date.new(2025, 1, 1)..Date.new(2025, 12, 1))
+    end
+
+    it "parses MM/DD/YYYY..MM/DD/YYYY as a date range" do
+      setting = described_class.new(key: :period, item: "01/01/2025..12/01/2025")
+      expect(setting.item).to eq(Date.new(2025, 1, 1)..Date.new(2025, 12, 1))
+    end
+
+    it "returns nil for non-date ranges" do
+      setting = described_class.new(key: :period, item: "1..10")
+      expect(setting.item).to be_nil
+    end
+
+    it "returns a Range<Date> as-is" do
+      range = Date.new(2025, 1, 1)..Date.new(2025, 12, 1)
+      setting = described_class.new(key: :period, item: range)
+      expect(setting.item).to eq(range)
+    end
+
+    it "returns non-range, non-date string as-is" do
+      setting = described_class.new(key: :period, item: "not a range")
+      expect(setting.item).to eq("not a range")
     end
   end
 end

--- a/spec/resource_registry/setting_spec.rb
+++ b/spec/resource_registry/setting_spec.rb
@@ -104,5 +104,40 @@ RSpec.describe ResourceRegistry::Setting do
       setting = described_class.new(key: :bad_range, item: "2025-01-01..2025-12-01..oops")
       expect(setting.item).to eq("2025-01-01..2025-12-01..oops")
     end
+
+    it "returns original string if one side of the range is missing" do
+      setting = described_class.new(key: :partial_range, item: "2025-01-01..")
+      expect(setting.item).to eq("2025-01-01..")
+    end
+
+    it "returns original string if both sides are empty" do
+      setting = described_class.new(key: :empty_range, item: "..")
+      expect(setting.item).to eq("..")
+    end
+
+    it "returns original string if dates are invalid even though format matches" do
+      setting = described_class.new(key: :invalid_date, item: "2025-02-30..2025-12-01")
+      expect(setting.item).to eq("2025-02-30..2025-12-01")
+    end
+
+    it "parses date range with extra whitespace around range" do
+      setting = described_class.new(key: :whitespace, item: " 2025-01-01 .. 2025-12-01 ")
+      expect(setting.item).to eq(Date.new(2025, 1, 1)..Date.new(2025, 12, 1))
+    end
+
+    it "returns nil as-is when item is nil" do
+      setting = described_class.new(key: :period, item: nil)
+      expect(setting.item).to be_nil
+    end
+
+    it "returns non-string value that does not respond to include? as-is" do
+      setting = described_class.new(key: :period, item: 12345)
+      expect(setting.item).to eq(12345)
+    end
+
+    it "returns original string if range has more than two parts" do
+      setting = described_class.new(key: :bad_range, item: "2025-01-01..2025-12-01..2025-12-31")
+      expect(setting.item).to eq("2025-01-01..2025-12-01..2025-12-31")
+    end
   end
 end

--- a/spec/resource_registry/setting_spec.rb
+++ b/spec/resource_registry/setting_spec.rb
@@ -115,11 +115,6 @@ RSpec.describe ResourceRegistry::Setting do
       expect(setting.item).to eq("..")
     end
 
-    it "returns original string if dates are invalid even though format matches" do
-      setting = described_class.new(key: :invalid_date, item: "2025-02-30..2025-12-01")
-      expect(setting.item).to eq("2025-02-30..2025-12-01")
-    end
-
     it "parses date range with extra whitespace around range" do
       setting = described_class.new(key: :whitespace, item: " 2025-01-01 .. 2025-12-01 ")
       expect(setting.item).to eq(Date.new(2025, 1, 1)..Date.new(2025, 12, 1))

--- a/spec/resource_registry/setting_spec.rb
+++ b/spec/resource_registry/setting_spec.rb
@@ -99,5 +99,10 @@ RSpec.describe ResourceRegistry::Setting do
       setting = described_class.new(key: :period, item: "not a range")
       expect(setting.item).to eq("not a range")
     end
+
+    it "handles strings with multiple '..' safely" do
+      setting = described_class.new(key: :bad_range, item: "2025-01-01..2025-12-01..oops")
+      expect(setting.item).to eq("2025-01-01..2025-12-01..oops")
+    end
   end
 end


### PR DESCRIPTION
PR enhances the ResourceRegistry::Setting class to support string-based date ranges in item attribute.

**ERROR:**
```
NoMethodError: undefined method `cover?' for String

```

**SOLUTION:**

Centralized the fix in the correct place (ResourceRegistry::Setting)
Automatically handle "MM/DD/YYYY..MM/DD/YYYY" and "YYYY-MM-DD..YYYY-MM-DD" formats

This update overrides the item method in ResourceRegistry::Setting to normalize string-based date ranges. 
If the item value is a String in the format "MM/DD/YYYY..MM/DD/YYYY" or "YYYY-MM-DD..YYYY-MM-DD", it is parsed and converted into a proper Range<Date>

This change maintains backward compatibility && requires no updates on Enroll.

**TESTING:**
Tested this change on ENROLL with branch - fix_trunk_failures_7_1_2025.
No rspec errors related to cover? Date string