### PR TITLE
add flag_type to Meta struct to classify feature flag lifecycle

### DIFF
--- a/lib/resource_registry/meta.rb
+++ b/lib/resource_registry/meta.rb
@@ -42,9 +42,9 @@ module ResourceRegistry
     #                    behaviour is enabled for all clients, the old code path is dead and the
     #                    flag should be removed. This is the most common type.
     #
-    #   :configuration - A permanent toggle that supports genuinely different behaviours for
-    #                    different clients (e.g. state-specific rules). Both the enabled and
-    #                    disabled code paths are always needed. Do not clean up.
+    #   :configuration - A permanent toggle that supports different business rules or policies
+    #                    across clients. Both the enabled and disabled code paths are always
+    #                    needed for different clients. Do not clean up.
     #
     # Example (in registry YML):
     #   meta:

--- a/lib/resource_registry/meta.rb
+++ b/lib/resource_registry/meta.rb
@@ -33,6 +33,30 @@ module ResourceRegistry
     # @return [String]
     attribute :description, Types::String.optional.meta(omittable: true)
 
+    # @!attribute [r] flag_type
+    # Indicates the intended lifecycle of this feature flag. Set this when the flag is created so
+    # that future engineers know whether dead-code cleanup is expected.
+    #
+    # Accepted values:
+    #   :release       - A temporary gate used to safely roll out new behaviour. Once the new
+    #                    behaviour is enabled for all clients, the old code path is dead and the
+    #                    flag should be removed. This is the most common type.
+    #
+    #   :configuration - A permanent toggle that supports genuinely different behaviours for
+    #                    different clients (e.g. state-specific rules). Both the enabled and
+    #                    disabled code paths are always needed. Do not clean up.
+    #
+    # Example (in registry YML):
+    #   meta:
+    #     label: "Enable New Enrollment Flow"
+    #     content_type: :boolean
+    #     default: false
+    #     flag_type: :release
+    #     description: "Switches enrollment to the redesigned multi-step flow."
+    #
+    # @return [Symbol] :release or :configuration
+    attribute :flag_type, Types::Symbol.optional.meta(omittable: true)
+
     # @!attribute [r] enum
     # List of vaalid domain values when configuration values are constrained to an enumerated set
     # @return [Array<Any>]

--- a/lib/resource_registry/models/mongoid/meta.rb
+++ b/lib/resource_registry/models/mongoid/meta.rb
@@ -14,6 +14,9 @@ module ResourceRegistry
       field :enum,          type: Array
       field :is_required,   type: Boolean
       field :is_visible,    type: Boolean
+      # :release — temporary rollout gate; clean up once enabled for all clients.
+      # :configuration — permanent per-client toggle; both paths always needed.
+      field :flag_type,     type: Symbol
 
     end
   end

--- a/lib/resource_registry/models/mongoid/meta.rb
+++ b/lib/resource_registry/models/mongoid/meta.rb
@@ -14,9 +14,6 @@ module ResourceRegistry
       field :enum,          type: Array
       field :is_required,   type: Boolean
       field :is_visible,    type: Boolean
-      # :release — temporary rollout gate; clean up once enabled for all clients.
-      # :configuration — permanent per-client toggle; both paths always needed.
-      field :flag_type,     type: Symbol
 
     end
   end

--- a/lib/resource_registry/validation/meta_contract.rb
+++ b/lib/resource_registry/validation/meta_contract.rb
@@ -27,14 +27,7 @@ module ResourceRegistry
         optional(:enum).maybe(:array)
         optional(:is_required).maybe(:bool)
         optional(:is_visible).maybe(:bool)
-        optional(:flag_type).maybe(:symbol)
-      end
-
-      rule(:flag_type) do
-        next unless value
-        unless %i[release configuration].include?(value)
-          key.failure("must be :release or :configuration")
-        end
+        optional(:flag_type).maybe(:symbol, included_in?: %i[release configuration])
       end
 
     end

--- a/lib/resource_registry/validation/meta_contract.rb
+++ b/lib/resource_registry/validation/meta_contract.rb
@@ -15,6 +15,7 @@ module ResourceRegistry
       # @option opts [Array<Any>] :enum optional
       # @option opts [Bool] :is_required optional
       # @option opts [Bool] :is_visible optional
+      # @option opts [Symbol] :flag_type optional - :release or :configuration
       # @return [Dry::Monads::Result::Success] if params pass validation
       # @return [Dry::Monads::Result::Failure] if params fail validation
       params do
@@ -26,6 +27,14 @@ module ResourceRegistry
         optional(:enum).maybe(:array)
         optional(:is_required).maybe(:bool)
         optional(:is_visible).maybe(:bool)
+        optional(:flag_type).maybe(:symbol)
+      end
+
+      rule(:flag_type) do
+        next unless value
+        unless %i[release configuration].include?(value)
+          key.failure("must be :release or :configuration")
+        end
       end
 
     end

--- a/spec/resource_registry/meta_spec.rb
+++ b/spec/resource_registry/meta_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ResourceRegistry::Meta do
       is_visible: is_visible
     }
   end
-  let(:all_params)        { required_params.merge(optional_params) }
+  let(:all_params) { required_params.merge(optional_params) }
 
   context "Validation with valid input" do
     context "Given hash params include only required attributes" do
@@ -37,6 +37,29 @@ RSpec.describe ResourceRegistry::Meta do
       it "should pass validation" do
         expect(described_class.new(all_params)).to be_a ResourceRegistry::Meta
         expect(described_class.new(all_params).to_h).to eq all_params
+      end
+    end
+  end
+
+  describe "#flag_type" do
+    context "when flag_type is :release" do
+      it "accepts the value" do
+        meta = described_class.new(required_params.merge(flag_type: :release))
+        expect(meta.flag_type).to eq :release
+      end
+    end
+
+    context "when flag_type is :configuration" do
+      it "accepts the value" do
+        meta = described_class.new(required_params.merge(flag_type: :configuration))
+        expect(meta.flag_type).to eq :configuration
+      end
+    end
+
+    context "when flag_type is absent" do
+      it "defaults to nil" do
+        meta = described_class.new(required_params)
+        expect(meta.flag_type).to be_nil
       end
     end
   end

--- a/spec/resource_registry/validation/meta_contract_spec.rb
+++ b/spec/resource_registry/validation/meta_contract_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ResourceRegistry::Validation::MetaContract do
       it "fails validation" do
         result = subject.call(required_params.merge(flag_type: :temporary))
         expect(result.failure?).to be_truthy
-        expect(result.errors.to_h[:flag_type]).to include("must be :release or :configuration")
+        expect(result.errors.to_h[:flag_type]).to include("must be one of: release, configuration")
       end
     end
 

--- a/spec/resource_registry/validation/meta_contract_spec.rb
+++ b/spec/resource_registry/validation/meta_contract_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ResourceRegistry::Validation::MetaContract do
   let(:is_required) { false }
   let(:is_visible)  { false }
 
-  let(:required_params)   { { label: label, content_type: type, default: default} }
+  let(:required_params) { { label: label, content_type: type, default: default } }
   let(:optional_params) do
     {
       value: value,
@@ -23,7 +23,7 @@ RSpec.describe ResourceRegistry::Validation::MetaContract do
       is_visible: is_visible
     }
   end
-  let(:all_params)        { required_params.merge(optional_params) }
+  let(:all_params) { required_params.merge(optional_params) }
 
   context "Validation with invalid input" do
     let(:required_params_error) { { :default => ["is missing"], :label => ["is missing"], :content_type => ["is missing"] } }
@@ -48,10 +48,40 @@ RSpec.describe ResourceRegistry::Validation::MetaContract do
       end
     end
 
-    context "Given hash params include all required nd optional attributes" do
+    context "Given hash params include all required and optional attributes" do
       it "should pass validation" do
         expect(subject.call(all_params).success?).to be_truthy
         expect(subject.call(all_params).to_h).to eq all_params
+      end
+    end
+  end
+
+  describe "flag_type validation" do
+    context "when flag_type is :release" do
+      it "passes validation" do
+        result = subject.call(required_params.merge(flag_type: :release))
+        expect(result.success?).to be_truthy
+      end
+    end
+
+    context "when flag_type is :configuration" do
+      it "passes validation" do
+        result = subject.call(required_params.merge(flag_type: :configuration))
+        expect(result.success?).to be_truthy
+      end
+    end
+
+    context "when flag_type is an unrecognised value" do
+      it "fails validation" do
+        result = subject.call(required_params.merge(flag_type: :temporary))
+        expect(result.failure?).to be_truthy
+        expect(result.errors.to_h[:flag_type]).to include("must be :release or :configuration")
+      end
+    end
+
+    context "when flag_type is absent" do
+      it "passes validation" do
+        expect(subject.call(required_params).success?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
[CU-868jj1wtq](https://app.clickup.com/t/868jj1wtq)


This pull request introduces a new optional `flag_type` attribute to the feature flag metadata, clarifying the intended lifecycle of each flag (either temporary for release or permanent for configuration). The change is supported by schema validation and comprehensive tests to ensure only valid values are accepted.

**Feature flag lifecycle support:**
- Added an optional `flag_type` attribute to the `Meta` struct, with documentation explaining its purpose and accepted values (`:release` or `:configuration`). This helps future engineers understand whether a flag is meant for eventual removal or is a permanent configuration toggle.

**Validation enhancements:**
- Updated the `MetaContract` validation schema to accept the new `flag_type` attribute and restrict its values to `:release` or `:configuration`. [[1]](diffhunk://#diff-99a3cbbe9b948f6edcf05e33dcda83375a9843a68f8d0fca1a2f52c9f75805bbR18) [[2]](diffhunk://#diff-99a3cbbe9b948f6edcf05e33dcda83375a9843a68f8d0fca1a2f52c9f75805bbR30)

**Testing improvements:**
- Added tests to `meta_spec.rb` to verify that `flag_type` is accepted when set to valid values, and defaults to `nil` when absent.
- Added validation tests to `meta_contract_spec.rb` to ensure only valid `flag_type` values are accepted, invalid values are rejected, and absence of the attribute passes validation.